### PR TITLE
Add chip components, clipboard intercept, and inline parser features

### DIFF
--- a/src/chip-component.ts
+++ b/src/chip-component.ts
@@ -37,6 +37,7 @@ export function buildChipElement(token: ParsedVcToken, plugin: VaultCryptPlugin)
 	});
 
 	const root = document.createElement('span');
+	root.dataset.vcChip = '';
 	const chipState = signal<'locked' | 'masked' | 'revealed' | 'unknown' | 'masked-error'>('locked');
 	const errorReason = signal<string>('');
 
@@ -120,12 +121,14 @@ export function buildChipElement(token: ParsedVcToken, plugin: VaultCryptPlugin)
 	function renderUnknown() {
 		if (!peek(profileConfig)) {
 			root.className = 'vaultcrypt-chip vaultcrypt-chip-error';
+			root.dataset.vcCopyText = '[unknown]';
 			root.textContent = `⚠ unknown profile: ${token.profileId}`;
 		}
 	}
 
 	function renderLocked() {
 		root.className = 'vaultcrypt-chip vaultcrypt-chip-locked';
+		root.dataset.vcCopyText = '[locked]';
 		root.replaceChildren();
 		const label = document.createElement('span');
 		label.textContent = compact() ? '🔒 ••••••••' : `🔒 ${tooltipPath()}`;
@@ -141,6 +144,7 @@ export function buildChipElement(token: ParsedVcToken, plugin: VaultCryptPlugin)
 
 	function renderMasked() {
 		root.className = 'vaultcrypt-chip vaultcrypt-chip-masked';
+		root.dataset.vcCopyText = '[encrypted]';
 		root.replaceChildren();
 
 		const iconEl = document.createElement('span');
@@ -174,6 +178,7 @@ export function buildChipElement(token: ParsedVcToken, plugin: VaultCryptPlugin)
 
 	function renderMaskedError(reason: string) {
 		root.className = 'vaultcrypt-chip vaultcrypt-chip-masked-error';
+		root.dataset.vcCopyText = '[encrypted]';
 		root.replaceChildren();
 
 		const iconEl = document.createElement('span');
@@ -196,6 +201,7 @@ export function buildChipElement(token: ParsedVcToken, plugin: VaultCryptPlugin)
 
 	function renderRevealed(value: string) {
 		root.className = 'vaultcrypt-chip vaultcrypt-chip-revealed';
+		root.dataset.vcCopyText = value;
 		root.replaceChildren();
 
 		const iconEl = document.createElement('span');

--- a/src/clipboard-intercept.ts
+++ b/src/clipboard-intercept.ts
@@ -1,0 +1,168 @@
+import {VC_TOKEN_REGEX, parseVcTokens} from './inline-parser';
+import type VaultCryptPlugin from './main';
+import type {EditorView} from '@codemirror/view';
+
+/**
+ * Builds a clipboard-safe string from the current browser selection by
+ * replacing VaultCrypt chip elements with their appropriate copy text
+ * (plaintext when revealed, placeholder otherwise).
+ *
+ * Used for reading mode where chips are standard DOM elements.
+ * Returns `null` when the selection contains no VaultCrypt chips,
+ * signalling the caller should let the default copy behaviour proceed.
+ */
+export function buildCopyTextFromSelection(
+	selection: Selection,
+	plugin: VaultCryptPlugin,
+): string | null {
+	if (selection.rangeCount === 0) return null;
+
+	let containsChip = false;
+	let result = '';
+
+	for (let i = 0; i < selection.rangeCount; i++) {
+		const range = selection.getRangeAt(i);
+		const fragment = range.cloneContents();
+		result += walkNode(fragment);
+	}
+
+	if (!containsChip) return null;
+	return result;
+
+	// ── recursive walk ──────────────────────────────────────────────────
+
+	function walkNode(node: Node): string {
+		// Text node — include content, with safety-net replacement of raw tokens
+		if (node.nodeType === Node.TEXT_NODE) {
+			const text = node.textContent ?? '';
+			const re = new RegExp(VC_TOKEN_REGEX.source, 'g');
+			if (!re.test(text)) return text;
+
+			// Replace any leaked raw {{vc:...}} tokens
+			containsChip = true;
+			const re2 = new RegExp(VC_TOKEN_REGEX.source, 'g');
+			return text.replace(re2, (_match, profileId: string, entryPath: string, fieldName?: string) => {
+				return resolveTokenCopyText(plugin, profileId, entryPath, fieldName ?? null);
+			});
+		}
+
+		// Element node
+		if (node.nodeType === Node.ELEMENT_NODE) {
+			const el = node as HTMLElement;
+
+			// VaultCrypt chip — use stored copy text, skip children
+			if (el.dataset.vcChip !== undefined) {
+				containsChip = true;
+				return el.dataset.vcCopyText ?? '[encrypted]';
+			}
+
+			// Recurse into children
+			let text = '';
+			for (let j = 0; j < el.childNodes.length; j++) {
+				text += walkNode(el.childNodes[j]!);
+			}
+			return text;
+		}
+
+		return '';
+	}
+}
+
+/**
+ * Builds a clipboard-safe string from a CM6 editor view's selection by
+ * parsing the document text for vc tokens and replacing each with the
+ * appropriate copy text from the chip widget's DOM element.
+ *
+ * Returns `null` when the selection contains no VaultCrypt tokens.
+ */
+export function buildCopyTextFromEditorSelection(
+	view: EditorView,
+	plugin: VaultCryptPlugin,
+): string | null {
+	const {state} = view;
+	const ranges = state.selection.ranges;
+
+	let hasToken = false;
+	const parts: string[] = [];
+
+	for (const range of ranges) {
+		if (range.empty) continue;
+		const text = state.sliceDoc(range.from, range.to);
+		const tokens = parseVcTokens(text);
+
+		if (tokens.length === 0) {
+			parts.push(text);
+			continue;
+		}
+
+		hasToken = true;
+		let cursor = 0;
+		let result = '';
+
+		for (const token of tokens) {
+			result += text.slice(cursor, token.from);
+
+			// Try to find the chip widget element in the editor DOM
+			const absFrom = range.from + token.from;
+			const chipEl = findChipAtPos(view, absFrom);
+			if (chipEl) {
+				result += chipEl.dataset.vcCopyText ?? '[encrypted]';
+			} else {
+				// Token is visible as raw text (e.g. cursor inside it) — use fallback
+				result += resolveTokenCopyText(plugin, token.profileId, token.entryPath, token.fieldName);
+			}
+
+			cursor = token.to;
+		}
+
+		result += text.slice(cursor);
+		parts.push(result);
+	}
+
+	if (!hasToken) return null;
+	return parts.join(state.lineBreak);
+}
+
+/**
+ * Locates the chip widget DOM element rendered at a given document position.
+ */
+function findChipAtPos(view: EditorView, pos: number): HTMLElement | null {
+	try {
+		const domPos = view.domAtPos(pos);
+		const node = domPos.node;
+		const el = node instanceof HTMLElement ? node : node.parentElement;
+		if (!el) return null;
+		return el.closest<HTMLElement>('[data-vc-chip]') ??
+			el.querySelector<HTMLElement>('[data-vc-chip]') ??
+			null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Determines the appropriate clipboard text for a raw `{{vc:...}}` token
+ * that was found in a text node (e.g. when cursor is inside the token in
+ * CM6 and the decoration is suppressed).
+ */
+function resolveTokenCopyText(
+	plugin: VaultCryptPlugin,
+	profileId: string,
+	_entryPath: string,
+	_fieldName: string | null,
+): string {
+	const pid = profileId.toLowerCase();
+	const config = plugin.settings.profiles[pid];
+	if (!config) return '[unknown]';
+
+	const isLocked = plugin.vaultCryptState$().profiles.find(
+		p => p.id === pid,
+	)?.isLocked ?? true;
+
+	if (isLocked) return '[locked]';
+
+	// Profile is unlocked but the raw token is visible (cursor inside it),
+	// so the chip is not rendered and there is no revealed/masked state.
+	// Default to [encrypted] to avoid leaking plaintext without explicit reveal.
+	return '[encrypted]';
+}

--- a/src/editor-extension.ts
+++ b/src/editor-extension.ts
@@ -3,6 +3,7 @@ import {Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate, WidgetTyp
 import {Extension, RangeSetBuilder, StateEffect} from '@codemirror/state';
 import {parseVcTokens, ParsedVcToken} from './inline-parser';
 import {buildChipElement, CHIP_DESTROY_EVENT} from './chip-component';
+import {buildCopyTextFromEditorSelection} from './clipboard-intercept';
 import type VaultCryptPlugin from './main';
 
 /** Dispatching this effect on an EditorView forces chip decorations to rebuild. */
@@ -74,7 +75,7 @@ function buildDecorations(view: EditorView, plugin: VaultCryptPlugin): Decoratio
 }
 
 export function buildEditorExtension(plugin: VaultCryptPlugin): Extension {
-	return ViewPlugin.fromClass(
+	const viewPlugin = ViewPlugin.fromClass(
 		class {
 			decorations: DecorationSet;
 
@@ -93,4 +94,17 @@ export function buildEditorExtension(plugin: VaultCryptPlugin): Extension {
 		},
 		{decorations: v => v.decorations},
 	);
+
+	const copyHandler = EditorView.domEventHandlers({
+		copy(event: ClipboardEvent, view: EditorView) {
+			const copyText = buildCopyTextFromEditorSelection(view, plugin);
+			if (copyText === null) return false;
+
+			event.clipboardData?.setData('text/plain', copyText);
+			event.preventDefault();
+			return true;
+		},
+	});
+
+	return [viewPlugin, copyHandler];
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {VaultCryptProfile, VaultCryptState} from './types';
 import {buildEditorExtension, refreshChipsEffect} from './editor-extension';
 import {parseVcTokens, processVcTokensInDom, resolveFieldName} from './inline-parser';
 import {buildChipElement} from './chip-component';
+import {buildCopyTextFromSelection} from './clipboard-intercept';
 import {EditorView} from '@codemirror/view';
 import {Extension} from "@codemirror/state";
 import {computed, effect, peek, signal, StopEffect} from "@maverick-js/signals";
@@ -300,6 +301,23 @@ export default class VaultCryptPlugin extends Plugin {
 		// Reading mode post-processor
 		this.registerMarkdownPostProcessor((el) => {
 			processVcTokensInDom(el, (token) => buildChipElement(token, this));
+		});
+
+		// Clipboard interception for reading mode (CM6 is handled in editor-extension.ts)
+		this.registerDomEvent(document, 'copy', (event: ClipboardEvent) => {
+			const sel = window.getSelection();
+			if (!sel || sel.rangeCount === 0) return;
+
+			// Skip if selection is inside a CM6 editor (handled by the editor extension)
+			const ancestor = sel.getRangeAt(0).commonAncestorContainer;
+			const container = ancestor instanceof HTMLElement ? ancestor : ancestor.parentElement;
+			if (container?.closest('.cm-editor')) return;
+
+			const copyText = buildCopyTextFromSelection(sel, this);
+			if (copyText === null) return;
+
+			event.clipboardData?.setData('text/plain', copyText);
+			event.preventDefault();
 		});
 
 		// Settings tab

--- a/styles.css
+++ b/styles.css
@@ -32,7 +32,7 @@ If your plugin does not need CSS, delete this file.
 	background: rgba(var(--color-accent-rgb), 0.15);
 	color: var(--text-muted);
 	font-family: var(--font-monospace);
-	user-select: none;
+	user-select: all;
 	white-space: nowrap;
 	vertical-align: middle;
 }
@@ -82,6 +82,13 @@ If your plugin does not need CSS, delete this file.
 }
 
 
+
+/* Prevent selecting button/icon text inside chips */
+.vaultcrypt-chip-btn,
+.vaultcrypt-chip-icon,
+.vaultcrypt-chip-dots {
+	user-select: none;
+}
 
 /* Action buttons (copy, edit) inside a chip */
 .vaultcrypt-chip-btn {


### PR DESCRIPTION
## Overview
Major feature release with chip-based rendering, clipboard enhancements, and inline token parsing.

## Key Changes
- **Chip Component**: New interactive chip rendering with locked, masked, and revealed states
- **Clipboard Intercept**: Serialize chip state on copy instead of raw tokens; auto-clear timer with Electron fallback
- **Inline Parser**: Add `{{vc:...}}` token decoration and syntax highlighting support
- **Editor Extension**: Copy command for focused chips with improved clipboard handling
- **Unlock/Lock Lifecycle**: Centralize session management with dedicated callback handling
- **Settings**: Auto-unmask option, clipboard timer validation, and improved error handling
- **Profile Service**: Better identifier mapping and global lock state management

## Technical Updates
- Enhanced TypeScript configuration
- New CSS styling for interactive chip elements
- Improved error logging and debugging
- Removed unused preact/signals-core dependency
- Streamlined state management with reactive updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced clipboard handling for vault tokens in both editor and reading mode, ensuring encrypted or locked content is properly indicated instead of exposing raw token text.

* **Style**
  * Improved selection behavior for vault tokens—content is now selectable while internal controls remain unselectable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->