### PR TITLE
feat: attachment save/copy — desktop dialog, mobile share, 5 MB warning, binary copy disabled

### DIFF
--- a/src/attachment-chip.ts
+++ b/src/attachment-chip.ts
@@ -100,12 +100,13 @@ export function buildAttachmentChipElement(token: ParsedVcToken, plugin: VaultCr
 		root.className = 'vaultcrypt-chip vaultcrypt-chip-locked';
 		render(html`
 			<button type="button" class="vaultcrypt-chip-btn" aria-label="Unlock ${profileId}"
-				@click=${(evt: MouseEvent) => {
-					evt.stopPropagation();
-					new UnlockModal(plugin.app, plugin, profileId, () => {
-						chipState.set(resolveAttachmentState());
-					}).open();
-				}}>${compact() ? '🔒 ••••••••' : `🔒 ${profileId}/${token.entryPath}#${token.fieldName}`}</button>
+			        @click=${(evt: MouseEvent) => {
+						evt.stopPropagation();
+						new UnlockModal(plugin.app, plugin, profileId, () => {
+							chipState.set(resolveAttachmentState());
+						}).open();
+					}}>${compact() ? '🔒 ••••••••' : `🔒 ${profileId}/${token.entryPath}#${token.fieldName}`}
+			</button>
 		`, root);
 	}
 
@@ -114,19 +115,26 @@ export function buildAttachmentChipElement(token: ParsedVcToken, plugin: VaultCr
 		render(html`
 			<span class="vaultcrypt-chip-icon">📎</span>
 			<span class="vaultcrypt-chip-value">${filename}</span>
-			<button type="button" class="vaultcrypt-chip-btn" title="Save attachment" aria-label="Save attachment ${filename}"
-				@click=${(evt: MouseEvent) => {
-					evt.stopPropagation();
-					void saveAttachment();
-				}}>💾</button>
-			${isText
-				? html`<button type="button" class="vaultcrypt-chip-btn" title="Copy to clipboard" aria-label="Copy ${filename} to clipboard"
-					@click=${(evt: MouseEvent) => {
+			<button type="button" class="vaultcrypt-chip-btn" title="Save attachment"
+			        aria-label="Save attachment ${filename}"
+			        @click=${(evt: MouseEvent) => {
 						evt.stopPropagation();
-						copyAttachment();
-					}}>📋</button>`
-				: html`<button type="button" class="vaultcrypt-chip-btn" title="Binary file — use Save instead"
-					aria-label="Binary file — use Save instead" disabled>📋</button>`}
+						void saveAttachment();
+					}}>💾
+			</button>
+			${isText
+				? html`
+					<button type="button" class="vaultcrypt-chip-btn" title="Copy to clipboard"
+					        aria-label="Copy ${filename} to clipboard"
+					        @click=${(evt: MouseEvent) => {
+								evt.stopPropagation();
+								copyAttachment();
+							}}>📋
+					</button>`
+				: html`
+					<button type="button" class="vaultcrypt-chip-btn" title="Binary file — use Save instead"
+					        aria-label="Binary file — use Save instead" disabled>📋
+					</button>`}
 		`, root);
 	}
 
@@ -150,8 +158,10 @@ export function buildAttachmentChipElement(token: ParsedVcToken, plugin: VaultCr
 		if (Platform.isDesktop) {
 			// Scope the try/catch to Electron discovery only so that a failed write
 			// surfaces an explicit error rather than silently falling back to vault.
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
-			let dialog: {showSaveDialog(o: {defaultPath: string}): Promise<{canceled: boolean; filePath?: string}>} | undefined;
+			
+			let dialog: {
+				showSaveDialog(o: { defaultPath: string }): Promise<{ canceled: boolean; filePath?: string }>
+			} | undefined;
 			try {
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
 				dialog = (window as any).require?.('@electron/remote')?.dialog;
@@ -159,7 +169,7 @@ export function buildAttachmentChipElement(token: ParsedVcToken, plugin: VaultCr
 				dialog = undefined;
 			}
 			if (dialog) {
-				let result: {canceled: boolean; filePath?: string};
+				let result: { canceled: boolean; filePath?: string };
 				try {
 					result = await dialog.showSaveDialog({defaultPath: filename});
 				} catch (err) {
@@ -183,7 +193,8 @@ export function buildAttachmentChipElement(token: ParsedVcToken, plugin: VaultCr
 		// Mobile: try Web Share API.
 		if (Platform.isMobile) {
 			try {
-				if (navigator.share) {
+				const file = new File([data], filename, {type: 'application/octet-stream'});
+				if (navigator.canShare?.({files: [file]})) {
 					const file = new File([data], filename, {type: 'application/octet-stream'});
 					await navigator.share({files: [file]});
 					return;


### PR DESCRIPTION
## Summary

- **Desktop save**: invokes Electron `@electron/remote` `showSaveDialog` so the user picks the destination; falls back to vault save when `remote` is unavailable
- **Mobile save**: offers Web Share API (share sheet / Downloads); `AbortError` from user cancellation exits silently; other failures fall back to vault
- **5 MB guard**: `window.confirm` before any save path so large files don't write silently
- **Binary copy button**: rendered as `disabled` with tooltip `"Binary file — use Save instead"` instead of being hidden, per acceptance criteria

Closes #24

## Test plan

- [ ] Desktop: click 💾 on an attachment chip → OS save dialog appears → file written to chosen location, Notice shows full path
- [ ] Desktop (> 5 MB attachment): confirm dialog appears before save dialog; cancelling aborts cleanly
- [ ] Desktop (Electron unavailable / sandboxed): falls back to vault save with vault-path Notice
- [ ] Mobile: click 💾 → share sheet opens; cancelling share exits without error
- [ ] Mobile (no Share API): falls back to vault save
- [ ] Binary file chip: 📋 button is visible but disabled; hovering shows tooltip "Binary file — use Save instead"
- [ ] Text file chip: 📋 button is clickable and clipboard auto-clear still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save button label and accessibility text updated to “Save attachment …” for clarity.
  * Desktop now shows a native Save As dialog; mobile offers system Share; existing vault save is fallback.
  * Clipboard button always visible: enabled for text, shown disabled for binary with “Binary file — use Save instead.”
  * Success/failure notices displayed for save operations; large attachments prompt confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->